### PR TITLE
Fixed Screenshots Not Appearing In README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,27 +45,27 @@ Screenshots
 
 * **Super Mario Advance:**
 
-    ![Super Mario Advance](http://i.imgur.com/ewhtAJg.png "Super Mario Advance")
+    ![Super Mario Advance](http://i.imgur.com/ewhtAJg.png)
 
 * **Mario & Luigi Superstar Saga:**
 
-    ![Mario & Luigi Superstar Saga](http://i.imgur.com/Do8TbsMh.png "Mario & Luigi Superstar Saga")
+    ![Mario & Luigi Superstar Saga](http://i.imgur.com/Do8TbsMh.png)
 
 * **Mario Kart Advance:**
 
-    ![Mario Kart Advance](http://i.imgur.com/37xx3yPh.png “Super Circuit”)
+    ![Mario Kart Advance](http://i.imgur.com/37xx3yPh.png)
 
 * **Earthworm Jim:**
 
-    ![http://i.imgur.com/Ip3MHzmh.png “Earthworm Jim”]
+    ![Earthworm Jim](http://i.imgur.com/Ip3MHzmh.png)
 
 * **Advance Wars:**
 
-    ![Advance Wars](http://i.imgur.com/akKzA97h.png “Advance Wars”)
+    ![Advance Wars](http://i.imgur.com/akKzA97h.png )
 
 * **Wario Land 4:**
 
-    ![Wario Land 4](http://i.imgur.com/eaDqCxuh.png “Wario Land 4”)
+    ![Wario Land 4](http://i.imgur.com/eaDqCxuh.png )
 
 * **Golden Sun:**
 
@@ -73,8 +73,8 @@ Screenshots
 
 * **Game & Watch Gallery 4:**
 
-    ![Game & Watch Gallery 4](http://i.imgur.com/awLMWsIh.png “Game & Watch Gallery 4”)
+    ![Game & Watch Gallery 4](http://i.imgur.com/awLMWsIh.png )
 
 * **GBA BIOS:**
 
-    ![GBA BIOS](http://i.imgur.com/kzxGoAHh.png “GBA BIOS”)
+    ![GBA BIOS](http://i.imgur.com/kzxGoAHh.png )

--- a/README.md
+++ b/README.md
@@ -45,36 +45,36 @@ Screenshots
 
 * **Super Mario Advance:**
 
-    ![Super Mario Advance](http://i.imgur.com/ewhtAJg.png)
+    ![Super Mario Advance](http://i.imgur.com/ewhtAJg.png "Super Mario Advance")
 
 * **Mario & Luigi Superstar Saga:**
 
-    ![Mario & Luigi Superstar Saga](http://i.imgur.com/Do8TbsMh.png)
+    ![Mario & Luigi Superstar Saga](http://i.imgur.com/Do8TbsMh.png "Mario & Luigi Superstar Saga")
 
 * **Mario Kart Advance:**
 
-    ![Mario Kart Advance](http://i.imgur.com/37xx3yPh.png)
+    ![Mario Kart Advance](http://i.imgur.com/37xx3yPh.png "Mario Kart Advance")
 
 * **Earthworm Jim:**
 
-    ![Earthworm Jim](http://i.imgur.com/Ip3MHzmh.png)
+    ![Earthworm Jim](http://i.imgur.com/Ip3MHzmh.png "Earthworm Jim")
 
 * **Advance Wars:**
 
-    ![Advance Wars](http://i.imgur.com/akKzA97h.png )
+    ![Advance Wars](http://i.imgur.com/akKzA97h.png "Advance Wars")
 
 * **Wario Land 4:**
 
-    ![Wario Land 4](http://i.imgur.com/eaDqCxuh.png )
+    ![Wario Land 4](http://i.imgur.com/eaDqCxuh.png "Wario Land 4")
 
 * **Golden Sun:**
 
-    ![Golden Sun](http://i.imgur.com/EctuZxo.png)
+    ![Golden Sun](http://i.imgur.com/EctuZxo.png "Golden Sun")
 
 * **Game & Watch Gallery 4:**
 
-    ![Game & Watch Gallery 4](http://i.imgur.com/awLMWsIh.png )
+    ![Game & Watch Gallery 4](http://i.imgur.com/awLMWsIh.png "Game & Watch Gallery 4")
 
 * **GBA BIOS:**
 
-    ![GBA BIOS](http://i.imgur.com/kzxGoAHh.png )
+    ![GBA BIOS](http://i.imgur.com/kzxGoAHh.png "GBA BIOS")

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Screenshots
 
 * **Earthworm Jim:**
 
-    ![Earthworm Jim](http://i.imgur.com/Ip3MHzmh.png “Earthworm Jim”)
+    ![](http://i.imgur.com/Ip3MHzmh.png “Earthworm Jim”)
 
 * **Advance Wars:**
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Screenshots
 
 * **Earthworm Jim:**
 
-    ![](http://i.imgur.com/Ip3MHzmh.png “Earthworm Jim”)
+    ![http://i.imgur.com/Ip3MHzmh.png “Earthworm Jim”]
 
 * **Advance Wars:**
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Screenshots
 
 * **Golden Sun:**
 
-    ![Golden Sun](http://i.imgur.com/EctuZxo.png “Golden Sun”)
+    ![Golden Sun](http://i.imgur.com/EctuZxo.png)
 
 * **Game & Watch Gallery 4:**
 


### PR DESCRIPTION
There were incorrect quotation marks around the alternative text for a couple of the screenshots that were causing them to not display.